### PR TITLE
Minor typo in spoon-river-anthology.xhtml Reuben Pantier

### DIFF
--- a/src/epub/text/spoon-river-anthology.xhtml
+++ b/src/epub/text/spoon-river-anthology.xhtml
@@ -522,7 +522,7 @@
 				<br/>
 				<span>And the tears swam into my eyes.</span>
 				<br/>
-				<span>She though they were amorous tears and smiled</span>
+				<span>She thought they were amorous tears and smiled</span>
 				<br/>
 				<span>For thought of her conquest over me.</span>
 				<br/>


### PR DESCRIPTION
"she though they were" → "she thought they were"

cf https://www.google.no/search?tbm=bks&q=She+thought+they+were+amorous+tears+and+smiled